### PR TITLE
Pause/resume Navigation

### DIFF
--- a/easynav_interfaces/msg/NavigationControl.msg
+++ b/easynav_interfaces/msg/NavigationControl.msg
@@ -9,6 +9,10 @@ uint8 FAILED=5
 uint8 CANCEL=6
 uint8 CANCELLED=7
 uint8 ERROR=8
+uint8 PAUSE=9
+uint8 RESUME=10
+uint8 PAUSED=11
+uint8 RESUMED=12
 
 uint8 type
 

--- a/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
+++ b/easynav_support_py/easynav_goalmanager_py/goal_manager_client.py
@@ -16,12 +16,14 @@
 from __future__ import annotations
 
 from enum import Enum
+import time
 
 # Interfaces
 from easynav_interfaces.msg import NavigationControl
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Goals
 
+import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 
@@ -53,6 +55,7 @@ class GoalManagerClient:
         self.goal_topic = 'goal_pose'
 
         self.state = ClientState.IDLE
+        self.paused = False
 
         self.last_control = NavigationControl()
         self.last_feedback = NavigationControl()
@@ -121,6 +124,66 @@ class GoalManagerClient:
 
         self._control_pub.publish(msg)
 
+    def pause(self) -> None:
+        """Pause whatever navigation is currently active.
+
+        Unlike cancel(), this is not restricted to a goal this client itself
+        commanded: any GoalManagerClient may pause/resume the active
+        navigation (e.g. an operator tool or a fleet-level conflict monitor
+        pausing a robot it doesn't own).
+        """
+        self.node.get_logger().debug('Sending navigation pause')
+
+        msg = NavigationControl()
+        msg.type = NavigationControl.PAUSE
+        msg.header = self.last_control.header
+        msg.user_id = self.id
+        msg.seq = self.last_control.seq + 1
+
+        self.node.get_logger().debug('Navigation pause sent')
+
+        self._control_pub.publish(msg)
+
+    def resume(self) -> None:
+        """Resume a previously paused navigation."""
+        self.node.get_logger().debug('Sending navigation resume')
+
+        msg = NavigationControl()
+        msg.type = NavigationControl.RESUME
+        msg.header = self.last_control.header
+        msg.user_id = self.id
+        msg.seq = self.last_control.seq + 1
+
+        self.node.get_logger().debug('Navigation resume sent')
+
+        self._control_pub.publish(msg)
+
+    def is_paused(self) -> bool:
+        """Whether the currently navigating goal is paused."""
+        return self.paused
+
+    def wait_for_server(self, timeout_sec: float = 1.0) -> bool:
+        """Wait until this client is fully matched with a running GoalManager.
+
+        A short-lived client (e.g. a CLI invocation) that publishes right
+        after construction can otherwise lose its very first message -- or
+        the reply to it -- to a pub/sub discovery race, since the remote
+        GoalManager's publisher and subscriber are matched independently and
+        not necessarily at the same time. Waits for both directions.
+        """
+        def matched() -> bool:
+            return (
+                self._control_pub.get_subscription_count() > 0 and
+                self._control_sub.get_publisher_count() > 0
+            )
+
+        end = time.monotonic() + timeout_sec
+        while time.monotonic() < end:
+            if matched():
+                return True
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+        return matched()
+
     def reset(self) -> None:
         """Reset internal client state."""
         if (
@@ -159,6 +222,21 @@ class GoalManagerClient:
 
         self.node.get_logger().debug(
             f'Received a navigation {msg.type} msg with user_id {msg.user_id}')
+
+        # Unlike goal ownership (SENT_GOAL/ACCEPTED_AND_NAVIGATING/...), pause/resume
+        # confirmations can legitimately arrive while this client is IDLE: any
+        # GoalManagerClient may pause/resume whatever navigation is currently active,
+        # not just the one it commanded itself. Handled here, independent of state.
+        if msg.type == NavigationControl.PAUSED:
+            self.node.get_logger().debug('Navigation paused')
+            self.paused = True
+            self.last_control = msg
+            return
+        elif msg.type == NavigationControl.RESUMED:
+            self.node.get_logger().debug('Navigation resumed')
+            self.paused = False
+            self.last_control = msg
+            return
 
         if (
             self.state != ClientState.IDLE and
@@ -212,15 +290,18 @@ class GoalManagerClient:
                             self.node.get_logger().info('Navigation succesfully finished')
                             self.last_result = msg
                             self.state = ClientState.NAVIGATION_FINISHED
+                            self.paused = False
                         case NavigationControl.FAILED:
                             self.node.get_logger().error(
                                 'Navigation with error finished: %s"' % msg.status_message)
                             self.last_result = msg
                             self.state = ClientState.NAVIGATION_FAILED
+                            self.paused = False
                         case NavigationControl.CANCELLED:
                             self.node.get_logger().error('Navigation cancelled')
                             self.last_result = msg
                             self.state = ClientState.NAVIGATION_CANCELLED
+                            self.paused = False
                         case _:
                             self.node.get_logger().error(
                                 'State ACCEPTED_AND_NAVIGATING; Unexpected message: "%d": "%s"' %

--- a/easynav_support_py/test/test_goalmanager_client_unit.py
+++ b/easynav_support_py/test/test_goalmanager_client_unit.py
@@ -36,6 +36,8 @@ def spin_wait(node: Node, predicate, timeout=3.0, step=0.01):
 
 class TestGoalManagerClientUnit(unittest.TestCase):
 
+    _next_id = 0
+
     @classmethod
     def setUpClass(cls):
         rclpy.init()
@@ -45,7 +47,14 @@ class TestGoalManagerClientUnit(unittest.TestCase):
         rclpy.shutdown()
 
     def setUp(self):
-        self.node = Node('gm_client_unit_tester')
+        # A unique node name per test (rather than a fixed one reused across
+        # tests) avoids a DDS-level crosstalk race: rapidly destroying and
+        # recreating a node/topic with the exact same name within a single
+        # shared rclpy context can let an in-flight message meant for the
+        # previous test's subscriber be delivered to this test's fresh one.
+        self._test_id = TestGoalManagerClientUnit._next_id
+        TestGoalManagerClientUnit._next_id += 1
+        self.node = Node(f'gm_client_unit_tester_{self._test_id}')
         self.client = GoalManagerClient(self.node)
 
         self.server_pub = self.node.create_publisher(
@@ -211,4 +220,72 @@ class TestGoalManagerClientUnit(unittest.TestCase):
         msg_other.nav_current_user_id = 'someone_else'
         self.server_pub.publish(msg_other)
         time.sleep(0.05)
+        self.assertEqual(self.client.get_state(), ClientState.IDLE)
+
+    def test_pause_resume(self):
+        self.client.send_goals(self.goals)
+        self._publish_and_wait(
+            self._srv_msg(NavigationControl.ACCEPT),
+            lambda: self.client.get_state() == ClientState.ACCEPTED_AND_NAVIGATING)
+
+        self.assertFalse(self.client.is_paused())
+
+        self.client.pause()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.PAUSED),
+            lambda: self.client.is_paused())
+        self.assertTrue(ok)
+        # Pausing must not change the navigation state itself.
+        self.assertEqual(self.client.get_state(), ClientState.ACCEPTED_AND_NAVIGATING)
+
+        self.client.resume()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.RESUMED),
+            lambda: not self.client.is_paused())
+        self.assertTrue(ok)
+        self.assertEqual(self.client.get_state(), ClientState.ACCEPTED_AND_NAVIGATING)
+
+    def test_pause_flag_resets_on_finish(self):
+        self.client.send_goals(self.goals)
+        self._publish_and_wait(
+            self._srv_msg(NavigationControl.ACCEPT),
+            lambda: self.client.get_state() == ClientState.ACCEPTED_AND_NAVIGATING)
+
+        self.client.pause()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.PAUSED),
+            lambda: self.client.is_paused())
+        self.assertTrue(ok)
+
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.FINISHED, 'done'),
+            lambda: self.client.get_state() == ClientState.NAVIGATION_FINISHED)
+        self.assertTrue(ok)
+        self.assertFalse(self.client.is_paused())
+
+    def test_pause_resume_from_idle_third_party(self):
+        # Unlike cancel(), pause()/resume() are not restricted to a goal this
+        # client itself commanded: an operator tool or a fleet-level conflict
+        # monitor may call them while this client's own state is still IDLE
+        # (it never sent a goal of its own), and still observe the PAUSED
+        # confirmation for whatever navigation is active elsewhere.
+        self.assertEqual(self.client.get_state(), ClientState.IDLE)
+
+        try:
+            self.client.pause()
+        except Exception as e:
+            self.fail(f'pause() raised while IDLE: {e}')
+
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.PAUSED),
+            lambda: self.client.is_paused())
+        self.assertTrue(ok)
+        # Client-side goal-ownership state must stay untouched.
+        self.assertEqual(self.client.get_state(), ClientState.IDLE)
+
+        self.client.resume()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.RESUMED),
+            lambda: not self.client.is_paused())
+        self.assertTrue(ok)
         self.assertEqual(self.client.get_state(), ClientState.IDLE)

--- a/easynav_system/include/easynav_system/GoalManager.hpp
+++ b/easynav_system/include/easynav_system/GoalManager.hpp
@@ -90,6 +90,12 @@ public:
   [[nodiscard]] inline State get_state() const {return state_;}
 
   /**
+   * @brief Whether the current navigation (if any) is currently paused.
+   * @return True if paused.
+   */
+  [[nodiscard]] inline bool is_paused() const {return paused_;}
+
+  /**
    * @brief Mark the current goal as successfully completed.
    */
   void set_finished();
@@ -195,9 +201,17 @@ private:
   /// @brief Internal goal state.
   State state_ {State::IDLE};
 
+  /// @brief Whether the current navigation is paused: EasyNav still runs its
+  /// full cycle, but SystemNode publishes zero velocity while this is true.
+  bool paused_ {false};
+
   /// @brief Value of "navigation_state" as last pushed to NavState by this class
   /// (the sole writer of that key).
   State last_synced_navigation_state_ {State::IDLE};
+
+  /// @brief Value of "navigation_paused" as last pushed to NavState by this
+  /// class (the sole writer of that key).
+  bool last_synced_paused_ {false};
 
   /// @brief True once NavState's "goals" has been synced to an empty Goals() since
   /// the last time goals_ became non-empty (see accept_request()).

--- a/easynav_system/include/easynav_system/GoalManagerClient.hpp
+++ b/easynav_system/include/easynav_system/GoalManagerClient.hpp
@@ -81,6 +81,25 @@ public:
   void cancel();
 
   /**
+   * @brief Pause the currently navigating goal.
+   *
+   * EasyNav keeps running its full cycle, but publishes zero velocity
+   * until @ref resume is called.
+   */
+  void pause();
+
+  /**
+   * @brief Resume a previously paused goal.
+   */
+  void resume();
+
+  /**
+   * @brief Whether the currently navigating goal is paused.
+   * @return True if paused.
+   */
+  [[nodiscard]] bool is_paused() const {return paused_;}
+
+  /**
    * @brief Reset internal client state.
    */
   void reset();
@@ -133,6 +152,9 @@ private:
 
   /// @brief Internal state of the client.
   State state_;
+
+  /// @brief Whether the currently navigating goal is paused.
+  bool paused_ {false};
 
   /// @brief Callback for incoming control messages.
   void control_callback(easynav_interfaces::msg::NavigationControl::UniquePtr msg);

--- a/easynav_system/include/easynav_system/GoalManagerClient.hpp
+++ b/easynav_system/include/easynav_system/GoalManagerClient.hpp
@@ -81,10 +81,11 @@ public:
   void cancel();
 
   /**
-   * @brief Pause the currently navigating goal.
+   * @brief Pause the currently active EasyNav navigation.
    *
-   * EasyNav keeps running its full cycle, but publishes zero velocity
-   * until @ref resume is called.
+   * This request is not restricted to the current goal owner (e.g. operator
+   * tools may pause/resume navigation). EasyNav keeps running its full cycle,
+   * but publishes zero velocity until @ref resume is called.
    */
   void pause();
 

--- a/easynav_system/include/easynav_system/SystemNode.hpp
+++ b/easynav_system/include/easynav_system/SystemNode.hpp
@@ -133,6 +133,12 @@ public:
    */
   void system_cycle();
 
+  /**
+   * @brief Access to the shared navigation state (for testing and tools).
+   * @return Shared pointer to the NavState.
+   */
+  [[nodiscard]] std::shared_ptr<NavState> get_nav_state() const {return nav_state_;}
+
 private:
   /// @brief Real-time callback group.
   rclcpp::CallbackGroup::SharedPtr realtime_cbg_;

--- a/easynav_system/src/easynav_system/GoalManager.cpp
+++ b/easynav_system/src/easynav_system/GoalManager.cpp
@@ -74,6 +74,7 @@ GoalManager::GoalManager(
 : parent_node_(parent_node)
 {
   nav_state.set("navigation_state", state_);
+  nav_state.set("navigation_paused", paused_);
 
   // Use the constructor parameter directly here, not parent_node_: it's a live
   // shared_ptr for the duration of this constructor, no need to lock() it.
@@ -154,6 +155,7 @@ GoalManager::accept_request(
 
   goals_ = msg.goals;
   goals_synced_empty_ = false;
+  paused_ = false;
 
   current_client_id_ = msg.user_id;
   response.status_message = "Goal accepted";
@@ -230,8 +232,42 @@ GoalManager::control_callback(easynav_interfaces::msg::NavigationControl::Unique
           response.type = easynav_interfaces::msg::NavigationControl::CANCELLED;
           response.nav_current_user_id = current_client_id_;
           state_ = State::IDLE;
+          paused_ = false;
         }
       }
+      break;
+    case easynav_interfaces::msg::NavigationControl::PAUSE:
+      RCLCPP_DEBUG(node->get_logger(), "Navigation pause requested");
+
+      // Unlike CANCEL, pausing is not restricted to the goal's owner: any
+      // GoalManagerClient (an operator tool, a fleet-level conflict monitor...)
+      // may pause/resume whatever navigation is currently active.
+      if (state_ == State::IDLE) {
+        RCLCPP_DEBUG(node->get_logger(), "Navigation pause rejected (not navigating)");
+        response.status_message = "Nothing to pause; easynav is idle";
+        response.type = easynav_interfaces::msg::NavigationControl::REJECT;
+      } else {
+        RCLCPP_DEBUG(node->get_logger(), "Navigation pause accepted");
+        paused_ = true;
+        response.status_message = "Navigation paused";
+        response.type = easynav_interfaces::msg::NavigationControl::PAUSED;
+      }
+      response.nav_current_user_id = msg->user_id;
+      break;
+    case easynav_interfaces::msg::NavigationControl::RESUME:
+      RCLCPP_DEBUG(node->get_logger(), "Navigation resume requested");
+
+      if (state_ == State::IDLE) {
+        RCLCPP_DEBUG(node->get_logger(), "Navigation resume rejected (not navigating)");
+        response.status_message = "Nothing to resume; easynav is idle";
+        response.type = easynav_interfaces::msg::NavigationControl::REJECT;
+      } else {
+        RCLCPP_DEBUG(node->get_logger(), "Navigation resume accepted");
+        paused_ = false;
+        response.status_message = "Navigation resumed";
+        response.type = easynav_interfaces::msg::NavigationControl::RESUMED;
+      }
+      response.nav_current_user_id = msg->user_id;
       break;
     default:
       RCLCPP_WARN(node->get_logger(), "Received erroneous control message %d", msg->type);
@@ -273,6 +309,7 @@ GoalManager::set_finished()
 
   state_ = State::IDLE;
   goals_ = nav_msgs::msg::Goals();
+  paused_ = false;
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
@@ -294,6 +331,7 @@ GoalManager::set_error(const std::string & reason)
 
   state_ = State::IDLE;
   goals_ = nav_msgs::msg::Goals();
+  paused_ = false;
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
@@ -315,6 +353,7 @@ GoalManager::set_failed(const std::string & reason)
 
   state_ = State::IDLE;
   goals_ = nav_msgs::msg::Goals();
+  paused_ = false;
 
   easynav_interfaces::msg::NavigationControl response;
   response = *last_control_;
@@ -348,6 +387,11 @@ GoalManager::update(NavState & nav_state)
   if (last_synced_navigation_state_ != state_) {
     nav_state.set("navigation_state", state_);
     last_synced_navigation_state_ = state_;
+  }
+
+  if (last_synced_paused_ != paused_) {
+    nav_state.set("navigation_paused", paused_);
+    last_synced_paused_ = paused_;
   }
 
    // Keep published tolerances in sync with current parameters

--- a/easynav_system/src/easynav_system/GoalManagerClient.cpp
+++ b/easynav_system/src/easynav_system/GoalManagerClient.cpp
@@ -52,6 +52,25 @@ GoalManagerClient::control_callback(easynav_interfaces::msg::NavigationControl::
   RCLCPP_DEBUG(node_->get_logger(), "Received a navigation %d msg with user_id %s",
     msg->type, msg->user_id.c_str());
 
+  // Unlike goal ownership (SENT_GOAL/ACCEPTED_AND_NAVIGATING/...), pause/resume
+  // confirmations can legitimately arrive while this client is IDLE: any
+  // GoalManagerClient may pause/resume whatever navigation is currently active,
+  // not just the one it commanded itself. Handled here, independent of state_.
+  switch (msg->type) {
+    case easynav_interfaces::msg::NavigationControl::PAUSED:
+      RCLCPP_DEBUG(node_->get_logger(), "Navigation paused");
+      paused_ = true;
+      last_control_ = std::move(msg);
+      return;
+    case easynav_interfaces::msg::NavigationControl::RESUMED:
+      RCLCPP_DEBUG(node_->get_logger(), "Navigation resumed");
+      paused_ = false;
+      last_control_ = std::move(msg);
+      return;
+    default:
+      break;
+  }
+
   switch (state_) {
     case State::IDLE:
     case State::NAVIGATION_FINISHED:
@@ -115,6 +134,7 @@ GoalManagerClient::control_callback(easynav_interfaces::msg::NavigationControl::
           RCLCPP_INFO(node_->get_logger(), "Navigation succesfully finished");
           last_result_ = *msg;
           state_ = State::NAVIGATION_FINISHED;
+          paused_ = false;
           break;
         case easynav_interfaces::msg::NavigationControl::FAILED:
           RCLCPP_ERROR(
@@ -122,11 +142,13 @@ GoalManagerClient::control_callback(easynav_interfaces::msg::NavigationControl::
             msg->status_message.c_str());
           last_result_ = *msg;
           state_ = State::NAVIGATION_FAILED;
+          paused_ = false;
           break;
         case easynav_interfaces::msg::NavigationControl::CANCELLED:
           RCLCPP_INFO(node_->get_logger(), "Navigation cancelled");
           last_result_ = *msg;
           state_ = State::NAVIGATION_CANCELLED;
+          paused_ = false;
           break;
         default:
           RCLCPP_ERROR(
@@ -234,6 +256,48 @@ GoalManagerClient::cancel()
 
 
   RCLCPP_DEBUG(node_->get_logger(), "Navigation cancelation sent");
+  control_pub_->publish(msg);
+}
+
+void
+GoalManagerClient::pause()
+{
+  RCLCPP_DEBUG(node_->get_logger(), "Sending navigation pause");
+
+  // Unlike cancel(), pause()/resume() are not restricted to a goal this
+  // client itself commanded: any GoalManagerClient may pause/resume whatever
+  // navigation is currently active (e.g. an operator tool or a fleet-level
+  // conflict monitor pausing a robot it doesn't own).
+  if (last_control_ == nullptr) {
+    last_control_ = std::make_unique<easynav_interfaces::msg::NavigationControl>();
+  }
+
+  easynav_interfaces::msg::NavigationControl msg;
+  msg.type = easynav_interfaces::msg::NavigationControl::PAUSE;
+  msg.header = last_control_->header;
+  msg.user_id = id_;
+  msg.seq = last_control_->seq + 1;
+
+  RCLCPP_DEBUG(node_->get_logger(), "Navigation pause sent");
+  control_pub_->publish(msg);
+}
+
+void
+GoalManagerClient::resume()
+{
+  RCLCPP_DEBUG(node_->get_logger(), "Sending navigation resume");
+
+  if (last_control_ == nullptr) {
+    last_control_ = std::make_unique<easynav_interfaces::msg::NavigationControl>();
+  }
+
+  easynav_interfaces::msg::NavigationControl msg;
+  msg.type = easynav_interfaces::msg::NavigationControl::RESUME;
+  msg.header = last_control_->header;
+  msg.user_id = id_;
+  msg.seq = last_control_->seq + 1;
+
+  RCLCPP_DEBUG(node_->get_logger(), "Navigation resume sent");
   control_pub_->publish(msg);
 }
 

--- a/easynav_system/src/easynav_system/SystemNode.cpp
+++ b/easynav_system/src/easynav_system/SystemNode.cpp
@@ -223,6 +223,10 @@ SystemNode::system_cycle_rt()
     geometry_msgs::msg::TwistStamped current_cmd_vel;
     current_cmd_vel = nav_state_->get<geometry_msgs::msg::TwistStamped>("cmd_vel");
 
+    if (nav_state_->get_safe<bool>("navigation_paused")) {
+      current_cmd_vel.twist = geometry_msgs::msg::Twist();
+    }
+
     if (trigger_controller) {
       if (use_cmd_vel_stamped_ && vel_pub_stamped_->get_subscription_count()) {
         vel_pub_stamped_->publish(current_cmd_vel);

--- a/easynav_system/tests/CMakeLists.txt
+++ b/easynav_system/tests/CMakeLists.txt
@@ -3,3 +3,6 @@ target_link_libraries(goalmanager_tests ${PROJECT_NAME})
 
 ament_add_gtest(system_tfinfo_tests system_tfinfo_tests.cpp)
 target_link_libraries(system_tfinfo_tests ${PROJECT_NAME})
+
+ament_add_gtest(system_pause_tests system_pause_tests.cpp)
+target_link_libraries(system_pause_tests ${PROJECT_NAME})

--- a/easynav_system/tests/goalmanager_tests.cpp
+++ b/easynav_system/tests/goalmanager_tests.cpp
@@ -1428,3 +1428,285 @@ TEST_F(GoalManagerTestCase, update_respects_frequency_limit)
   ASSERT_GE(feedback_count, expected - 2);
   ASSERT_LE(feedback_count, expected + 2);
 }
+
+TEST_F(GoalManagerTestCase, PauseAndResumeCycle)
+{
+  auto nav_state = std::make_shared<easynav::NavState>();
+  nav_state->set("robot_pose", nav_msgs::msg::Odometry());
+
+  auto client_node = rclcpp::Node::make_shared("client_node");
+  auto system_node = rclcpp_lifecycle::LifecycleNode::make_shared("system_node");
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(client_node);
+  exe.add_node(system_node->get_node_base_interface());
+
+  auto gm_client = easynav::GoalManagerClient::make_shared(client_node);
+  auto gm_server = easynav::GoalManager::make_shared(*nav_state, system_node);
+
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_TRUE(nav_state->has("navigation_paused"));
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+  ASSERT_FALSE(gm_client->is_paused());
+
+  geometry_msgs::msg::PoseStamped goal;
+  goal.header.frame_id = "map";
+  goal.header.stamp = client_node->now();
+  goal.pose.position.x = 5.0;
+
+  gm_client->send_goal(goal);
+
+  rclcpp::Rate rate(20);
+  auto start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(gm_client->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+
+  gm_client->pause();
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(gm_server->is_paused());
+  ASSERT_TRUE(nav_state->get_safe<bool>("navigation_paused"));
+  ASSERT_TRUE(gm_client->is_paused());
+  // Pausing must not touch the navigation/goal state itself.
+  ASSERT_EQ(gm_server->get_state(), easynav::GoalManager::State::ACTIVE);
+  ASSERT_EQ(gm_client->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+
+  gm_client->resume();
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+  ASSERT_FALSE(gm_client->is_paused());
+  ASSERT_EQ(gm_client->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+}
+
+TEST_F(GoalManagerTestCase, PauseRejectedWhenIdle)
+{
+  auto nav_state = std::make_shared<easynav::NavState>();
+  nav_state->set("robot_pose", nav_msgs::msg::Odometry());
+
+  auto client_node = rclcpp::Node::make_shared("client_node");
+  auto system_node = rclcpp_lifecycle::LifecycleNode::make_shared("system_node");
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(client_node);
+  exe.add_node(system_node->get_node_base_interface());
+
+  easynav_interfaces::msg::NavigationControl last_control;
+  auto control_sub = client_node->create_subscription<easynav_interfaces::msg::NavigationControl>(
+    "easynav_control", 100,
+    [&last_control](easynav_interfaces::msg::NavigationControl::UniquePtr msg) {
+      last_control = *msg;
+    });
+  auto control_pub = client_node->create_publisher<easynav_interfaces::msg::NavigationControl>(
+    "easynav_control", 100);
+
+  auto gm_server = easynav::GoalManager::make_shared(*nav_state, system_node);
+
+  ASSERT_EQ(gm_server->get_state(), easynav::GoalManager::State::IDLE);
+
+  easynav_interfaces::msg::NavigationControl pause_msg;
+  pause_msg.type = easynav_interfaces::msg::NavigationControl::PAUSE;
+  pause_msg.user_id = "some_client";
+  control_pub->publish(pause_msg);
+
+  rclcpp::Rate rate(20);
+  auto start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(last_control.type, easynav_interfaces::msg::NavigationControl::REJECT);
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+}
+
+TEST_F(GoalManagerTestCase, PauseAcceptedFromThirdPartyClient)
+{
+  // Unlike CANCEL, PAUSE/RESUME are not restricted to the goal's owner: an
+  // operator tool or a fleet-level conflict monitor -- represented here by
+  // gm_client2, which never sent any goal of its own -- must be able to
+  // pause/resume whatever navigation client_node1 currently has active.
+  auto nav_state = std::make_shared<easynav::NavState>();
+  nav_state->set("robot_pose", nav_msgs::msg::Odometry());
+
+  auto client_node1 = rclcpp::Node::make_shared("client_node1");
+  auto client_node2 = rclcpp::Node::make_shared("client_node2");
+  auto system_node = rclcpp_lifecycle::LifecycleNode::make_shared("system_node");
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(client_node1);
+  exe.add_node(client_node2);
+  exe.add_node(system_node->get_node_base_interface());
+
+  auto gm_client1 = easynav::GoalManagerClient::make_shared(client_node1);
+  auto gm_client2 = easynav::GoalManagerClient::make_shared(client_node2);
+  auto gm_server = easynav::GoalManager::make_shared(*nav_state, system_node);
+
+  geometry_msgs::msg::PoseStamped goal;
+  goal.header.frame_id = "map";
+  goal.header.stamp = system_node->now();
+  goal.pose.position.x = 5.0;
+
+  gm_client1->send_goal(goal);
+
+  rclcpp::Rate rate(20);
+  auto start = system_node->now();
+  while (system_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(gm_client1->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+  ASSERT_EQ(gm_client2->get_state(), easynav::GoalManagerClient::State::IDLE);
+
+  gm_client2->pause();
+
+  start = system_node->now();
+  while (system_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(gm_server->is_paused());
+  ASSERT_TRUE(nav_state->get_safe<bool>("navigation_paused"));
+  ASSERT_TRUE(gm_client2->is_paused());
+  // The requester's own goal-ownership state must stay untouched.
+  ASSERT_EQ(gm_client2->get_state(), easynav::GoalManagerClient::State::IDLE);
+  // The owning client is not the one who paused, but the effect is still global.
+  ASSERT_EQ(gm_client1->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+
+  gm_client2->resume();
+
+  start = system_node->now();
+  while (system_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+  ASSERT_FALSE(gm_client2->is_paused());
+}
+
+TEST_F(GoalManagerTestCase, PauseFlagResetOnCancelAndFinish)
+{
+  auto nav_state = std::make_shared<easynav::NavState>();
+  nav_state->set("robot_pose", nav_msgs::msg::Odometry());
+
+  auto client_node = rclcpp::Node::make_shared("client_node");
+  auto system_node = rclcpp_lifecycle::LifecycleNode::make_shared("system_node");
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(client_node);
+  exe.add_node(system_node->get_node_base_interface());
+
+  auto gm_client = easynav::GoalManagerClient::make_shared(client_node);
+  auto gm_server = easynav::GoalManager::make_shared(*nav_state, system_node);
+
+  geometry_msgs::msg::PoseStamped goal;
+  goal.header.frame_id = "map";
+  goal.header.stamp = client_node->now();
+  goal.pose.position.x = 5.0;
+
+  gm_client->send_goal(goal);
+
+  rclcpp::Rate rate(20);
+  auto start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(gm_client->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+
+  gm_client->pause();
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(gm_server->is_paused());
+
+  // Cancelling a paused navigation must clear the pause flag too.
+  gm_client->cancel();
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(gm_server->get_state(), easynav::GoalManager::State::IDLE);
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+
+  gm_client->reset();
+
+  // A brand new goal must start unpaused.
+  goal.header.stamp = client_node->now();
+  gm_client->send_goal(goal);
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(gm_client->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+
+  gm_client->pause();
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(gm_server->is_paused());
+
+  // Finishing a paused navigation must also clear the pause flag.
+  gm_server->set_finished();
+
+  start = client_node->now();
+  while (client_node->now() - start < 400ms) {
+    gm_server->update(*nav_state);
+    exe.spin_some();
+    rate.sleep();
+  }
+
+  ASSERT_EQ(gm_server->get_state(), easynav::GoalManager::State::IDLE);
+  ASSERT_FALSE(gm_server->is_paused());
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+}

--- a/easynav_system/tests/system_pause_tests.cpp
+++ b/easynav_system/tests/system_pause_tests.cpp
@@ -1,0 +1,272 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "easynav_system/SystemNode.hpp"
+#include "easynav_system/GoalManagerClient.hpp"
+#include "easynav_common/types/NavState.hpp"
+
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "gtest/gtest.h"
+
+// This test binary is its own process (one gtest executable per
+// ament_add_gtest() entry), so it is safe to seed global parameter
+// overrides at rclcpp::init() time: they apply to any node in this
+// process that later declares a parameter with a matching name. This is
+// what lets ControllerNode (a private member of SystemNode, not otherwise
+// reachable from test code before on_configure() runs) load the
+// already-registered "easynav_controller/DummyController" plugin, which is
+// required to get SystemNode::system_cycle_rt()'s trigger_controller to
+// ever be true -- without a loaded plugin, ControllerNode::cycle_rt()
+// always returns false and SystemNode never publishes anything.
+class SystemPauseTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!initialized_) {
+      std::vector<const char *> argv{
+        "system_pause_tests",
+        "--ros-args",
+        "-p", "controller_types:=['dummy']",
+        "-p", "dummy.plugin:=easynav_controller/DummyController",
+      };
+      rclcpp::init(static_cast<int>(argv.size()), argv.data());
+      initialized_ = true;
+    }
+  }
+
+  void TearDown() override
+  {
+  }
+
+  static bool initialized_;
+};
+
+bool SystemPauseTest::initialized_ = false;
+
+using namespace std::chrono_literals;
+
+TEST_F(SystemPauseTest, PublishesZeroVelocityWhenPaused)
+{
+  auto system_node = std::make_shared<easynav::SystemNode>();
+
+  auto state = rclcpp_lifecycle::State();
+  ASSERT_EQ(system_node->on_configure(state), easynav::SystemNode::CallbackReturnT::SUCCESS);
+  ASSERT_EQ(system_node->on_activate(state), easynav::SystemNode::CallbackReturnT::SUCCESS);
+
+  auto nav_state = system_node->get_nav_state();
+  ASSERT_TRUE(nav_state->has("navigation_paused"));
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+
+  auto listener_node = rclcpp::Node::make_shared("cmd_vel_listener");
+  std::vector<geometry_msgs::msg::Twist> received;
+  auto sub = listener_node->create_subscription<geometry_msgs::msg::Twist>(
+    "cmd_vel", 10,
+    [&received](geometry_msgs::msg::Twist::UniquePtr msg) {
+      received.push_back(*msg);
+    });
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(listener_node);
+
+  // system_cycle_rt() only publishes when vel_pub_ has a matched subscriber
+  // (get_subscription_count() > 0); pub/sub discovery is asynchronous, so
+  // the listener must be matched *before* the first system_cycle_rt() call
+  // or that cycle's publish is silently skipped.
+  {
+    auto start = listener_node->now();
+    while (listener_node->now() - start < 2s && sub->get_publisher_count() == 0) {
+      exe.spin_some();
+      rclcpp::sleep_for(10ms);
+    }
+    ASSERT_GT(sub->get_publisher_count(), 0u);
+  }
+
+  geometry_msgs::msg::TwistStamped nonzero_cmd;
+  nonzero_cmd.twist.linear.x = 1.5;
+  nonzero_cmd.twist.angular.z = 0.5;
+
+  // Keep invoking system_cycle_rt() (as the RT thread would, at rt_freq)
+  // until a message arrives: ControllerMethodBase's own internal RT-cycle
+  // timing (isTime2RunRT(), independent of pause/resume) may make the very
+  // first call(s) a no-op, so a single call is not guaranteed to publish.
+  auto cycle_until_message = [&]() {
+      auto start = listener_node->now();
+      while (listener_node->now() - start < 1s && received.empty()) {
+        system_node->system_cycle_rt();
+        exe.spin_some();
+        rclcpp::sleep_for(10ms);
+      }
+    };
+
+  // Baseline: unpaused, the nonzero twist must be published unchanged.
+  nav_state->set("cmd_vel", nonzero_cmd);
+  cycle_until_message();
+  ASSERT_FALSE(received.empty());
+  EXPECT_DOUBLE_EQ(received.back().linear.x, 1.5);
+  EXPECT_DOUBLE_EQ(received.back().angular.z, 0.5);
+
+  // Paused: same nonzero cmd_vel in NavState, but the publish must be zero.
+  received.clear();
+  nav_state->set("navigation_paused", true);
+  nav_state->set("cmd_vel", nonzero_cmd);
+  cycle_until_message();
+  ASSERT_FALSE(received.empty());
+  EXPECT_DOUBLE_EQ(received.back().linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(received.back().linear.y, 0.0);
+  EXPECT_DOUBLE_EQ(received.back().linear.z, 0.0);
+  EXPECT_DOUBLE_EQ(received.back().angular.x, 0.0);
+  EXPECT_DOUBLE_EQ(received.back().angular.y, 0.0);
+  EXPECT_DOUBLE_EQ(received.back().angular.z, 0.0);
+
+  // Resumed: the nonzero twist must flow through again -- no regression
+  // after unpausing.
+  received.clear();
+  nav_state->set("navigation_paused", false);
+  nav_state->set("cmd_vel", nonzero_cmd);
+  cycle_until_message();
+  ASSERT_FALSE(received.empty());
+  EXPECT_DOUBLE_EQ(received.back().linear.x, 1.5);
+  EXPECT_DOUBLE_EQ(received.back().angular.z, 0.5);
+}
+
+TEST_F(SystemPauseTest, PauseEndToEndThroughGoalManagerClient)
+{
+  // The real regression test: GoalManagerClient::pause()/resume() ->
+  // GoalManager::control_callback() -> GoalManager::update() -> NavState ->
+  // SystemNode::system_cycle_rt(), with the rest of the cycle
+  // (sensors/localizer/controller) left completely untouched.
+  auto system_node = std::make_shared<easynav::SystemNode>();
+
+  auto state = rclcpp_lifecycle::State();
+  ASSERT_EQ(system_node->on_configure(state), easynav::SystemNode::CallbackReturnT::SUCCESS);
+  ASSERT_EQ(system_node->on_activate(state), easynav::SystemNode::CallbackReturnT::SUCCESS);
+
+  auto nav_state = system_node->get_nav_state();
+  nav_state->set("robot_pose", nav_msgs::msg::Odometry());
+
+  auto client_node = rclcpp::Node::make_shared("pause_client_node");
+  auto gm_client = easynav::GoalManagerClient::make_shared(client_node);
+
+  auto listener_node = rclcpp::Node::make_shared("cmd_vel_listener2");
+  std::vector<geometry_msgs::msg::Twist> received;
+  auto sub = listener_node->create_subscription<geometry_msgs::msg::Twist>(
+    "cmd_vel", 10,
+    [&received](geometry_msgs::msg::Twist::UniquePtr msg) {
+      received.push_back(*msg);
+    });
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(system_node->get_node_base_interface());
+  exe.add_node(client_node);
+  exe.add_node(listener_node);
+
+  // See PublishesZeroVelocityWhenPaused: wait for pub/sub discovery before
+  // relying on any system_cycle_rt() publish.
+  {
+    auto wstart = listener_node->now();
+    while (listener_node->now() - wstart < 2s && sub->get_publisher_count() == 0) {
+      exe.spin_some();
+      rclcpp::sleep_for(10ms);
+    }
+    ASSERT_GT(sub->get_publisher_count(), 0u);
+  }
+
+  rclcpp::Rate rate(50);
+
+  geometry_msgs::msg::PoseStamped goal;
+  goal.header.frame_id = "map";
+  goal.header.stamp = client_node->now();
+  goal.pose.position.x = 5.0;
+
+  gm_client->send_goal(goal);
+
+  auto start = client_node->now();
+  while (client_node->now() - start < 1s &&
+    gm_client->get_state() != easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING)
+  {
+    system_node->system_cycle();
+    exe.spin_some();
+    rate.sleep();
+  }
+  ASSERT_EQ(gm_client->get_state(), easynav::GoalManagerClient::State::ACCEPTED_AND_NAVIGATING);
+
+  geometry_msgs::msg::TwistStamped nonzero_cmd;
+  nonzero_cmd.twist.linear.x = 1.5;
+
+  // See PublishesZeroVelocityWhenPaused: keep invoking system_cycle_rt()
+  // until a message arrives, since ControllerMethodBase's own internal
+  // RT-cycle timing may make a single call a no-op.
+  auto cycle_until_message = [&]() {
+      auto wstart = listener_node->now();
+      while (listener_node->now() - wstart < 1s && received.empty()) {
+        system_node->system_cycle_rt();
+        exe.spin_some();
+        rclcpp::sleep_for(10ms);
+      }
+    };
+
+  // Before pausing: nonzero cmd_vel goes through.
+  received.clear();
+  nav_state->set("cmd_vel", nonzero_cmd);
+  cycle_until_message();
+  ASSERT_FALSE(received.empty());
+  EXPECT_DOUBLE_EQ(received.back().linear.x, 1.5);
+
+  // Pause via the real client -> server protocol.
+  gm_client->pause();
+  start = client_node->now();
+  while (client_node->now() - start < 1s && !gm_client->is_paused()) {
+    exe.spin_some();
+    rate.sleep();
+  }
+  ASSERT_TRUE(gm_client->is_paused());
+
+  // GoalManager::update() (the non-RT cycle) is what actually propagates
+  // paused_ into NavState -- receiving the message alone does not.
+  system_node->system_cycle();
+  ASSERT_TRUE(nav_state->get_safe<bool>("navigation_paused"));
+
+  received.clear();
+  nav_state->set("cmd_vel", nonzero_cmd);
+  cycle_until_message();
+  ASSERT_FALSE(received.empty());
+  EXPECT_DOUBLE_EQ(received.back().linear.x, 0.0);
+
+  // Resume via the real client -> server protocol.
+  gm_client->resume();
+  start = client_node->now();
+  while (client_node->now() - start < 1s && gm_client->is_paused()) {
+    exe.spin_some();
+    rate.sleep();
+  }
+  ASSERT_FALSE(gm_client->is_paused());
+
+  system_node->system_cycle();
+  ASSERT_FALSE(nav_state->get_safe<bool>("navigation_paused"));
+
+  received.clear();
+  nav_state->set("cmd_vel", nonzero_cmd);
+  cycle_until_message();
+  ASSERT_FALSE(received.empty());
+  EXPECT_DOUBLE_EQ(received.back().linear.x, 1.5);
+}

--- a/easynav_tools/easynav_tools/cli/pause.py
+++ b/easynav_tools/easynav_tools/cli/pause.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Intelligent Robotics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import time
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+
+from ros2cli.node.strategy import add_arguments, NodeStrategy
+from ros2cli.verb import VerbExtension
+
+from easynav_goalmanager_py.goal_manager_client import GoalManagerClient
+
+from easynav_interfaces.msg import NavigationControl
+
+
+class PauseVerb(VerbExtension):
+    """Pause whatever EasyNav navigation is currently active."""
+
+    def add_arguments(self, parser, cli_name):
+        add_arguments(parser)
+        parser.add_argument(
+            '--timeout', type=float, default=3.0,
+            help='Seconds to wait for a confirmation from EasyNav')
+
+    def main(self, *, args):
+        with NodeStrategy(args) as node:
+            client = GoalManagerClient(node)
+
+            try:
+                if not client.wait_for_server(timeout_sec=min(args.timeout, 2.0)):
+                    print(
+                        'Timed out waiting to discover a running EasyNav instance.',
+                        file=sys.stderr)
+                    return 1
+
+                # Retry the request every 0.5s until a reply arrives: even
+                # after wait_for_server() reports a match, a very-short-lived
+                # client can still lose the first message to a residual
+                # discovery race.
+                t_end = time.time() + args.timeout
+                response = NavigationControl()
+                next_send = 0.0
+                while time.time() < t_end:
+                    if time.time() >= next_send:
+                        client.pause()
+                        next_send = time.time() + 0.5
+                    rclpy.spin_once(node, timeout_sec=0.1)
+                    response = client.get_last_control()
+                    if response.type in (NavigationControl.PAUSED, NavigationControl.REJECT):
+                        break
+            except (KeyboardInterrupt, ExternalShutdownException):
+                return 1
+
+            if response.type == NavigationControl.PAUSED:
+                print('Navigation paused.')
+                return 0
+            elif response.type == NavigationControl.REJECT:
+                print(f'Pause rejected: {response.status_message}', file=sys.stderr)
+                return 1
+            else:
+                print(
+                    'No confirmation received from EasyNav (is it running?).',
+                    file=sys.stderr)
+                return 1

--- a/easynav_tools/easynav_tools/cli/resume.py
+++ b/easynav_tools/easynav_tools/cli/resume.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Intelligent Robotics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import time
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+
+from ros2cli.node.strategy import add_arguments, NodeStrategy
+from ros2cli.verb import VerbExtension
+
+from easynav_goalmanager_py.goal_manager_client import GoalManagerClient
+
+from easynav_interfaces.msg import NavigationControl
+
+
+class ResumeVerb(VerbExtension):
+    """Resume a previously paused EasyNav navigation."""
+
+    def add_arguments(self, parser, cli_name):
+        add_arguments(parser)
+        parser.add_argument(
+            '--timeout', type=float, default=3.0,
+            help='Seconds to wait for a confirmation from EasyNav')
+
+    def main(self, *, args):
+        with NodeStrategy(args) as node:
+            client = GoalManagerClient(node)
+
+            try:
+                if not client.wait_for_server(timeout_sec=min(args.timeout, 2.0)):
+                    print(
+                        'Timed out waiting to discover a running EasyNav instance.',
+                        file=sys.stderr)
+                    return 1
+
+                # Retry the request every 0.5s until a reply arrives: even
+                # after wait_for_server() reports a match, a very-short-lived
+                # client can still lose the first message to a residual
+                # discovery race.
+                t_end = time.time() + args.timeout
+                response = NavigationControl()
+                next_send = 0.0
+                while time.time() < t_end:
+                    if time.time() >= next_send:
+                        client.resume()
+                        next_send = time.time() + 0.5
+                    rclpy.spin_once(node, timeout_sec=0.1)
+                    response = client.get_last_control()
+                    if response.type in (NavigationControl.RESUMED, NavigationControl.REJECT):
+                        break
+            except (KeyboardInterrupt, ExternalShutdownException):
+                return 1
+
+            if response.type == NavigationControl.RESUMED:
+                print('Navigation resumed.')
+                return 0
+            elif response.type == NavigationControl.REJECT:
+                print(f'Resume rejected: {response.status_message}', file=sys.stderr)
+                return 1
+            else:
+                print(
+                    'No confirmation received from EasyNav (is it running?).',
+                    file=sys.stderr)
+                return 1

--- a/easynav_tools/easynav_tools/controller/ros_controllers.py
+++ b/easynav_tools/easynav_tools/controller/ros_controllers.py
@@ -75,6 +75,10 @@ NC_TYPE_MAP: dict[int, tuple[str, str]] = {
     6: ('CANCEL',    'yellow'),
     7: ('CANCELLED', 'yellow'),
     8: ('ERROR',     'red'),
+    9: ('PAUSE',     'yellow'),
+    10: ('RESUME',   'green'),
+    11: ('PAUSED',   'yellow'),
+    12: ('RESUMED',  'green'),
 }
 
 

--- a/easynav_tools/setup.py
+++ b/easynav_tools/setup.py
@@ -41,6 +41,8 @@ setup(
             'nav_state = easynav_tools.cli.nav_state:NavStateVerb',
             'timestats = easynav_tools.cli.timetats:TimeStatsVerb',
             'plugins = easynav_tools.cli.plugins:PluginsVerb',
+            'pause = easynav_tools.cli.pause:PauseVerb',
+            'resume = easynav_tools.cli.resume:ResumeVerb',
         ],
     },
 )

--- a/easynav_tools/test/test_goalmanager_client_unit.py
+++ b/easynav_tools/test/test_goalmanager_client_unit.py
@@ -36,6 +36,8 @@ def spin_wait(node: Node, predicate, timeout=3.0, step=0.01):
 
 class TestGoalManagerClientUnit(unittest.TestCase):
 
+    _next_id = 0
+
     @classmethod
     def setUpClass(cls):
         rclpy.init()
@@ -45,7 +47,14 @@ class TestGoalManagerClientUnit(unittest.TestCase):
         rclpy.shutdown()
 
     def setUp(self):
-        self.node = Node('gm_client_unit_tester')
+        # A unique node name per test (rather than a fixed one reused across
+        # tests) avoids a DDS-level crosstalk race: rapidly destroying and
+        # recreating a node/topic with the exact same name within a single
+        # shared rclpy context can let an in-flight message meant for the
+        # previous test's subscriber be delivered to this test's fresh one.
+        self._test_id = TestGoalManagerClientUnit._next_id
+        TestGoalManagerClientUnit._next_id += 1
+        self.node = Node(f'gm_client_unit_tester_{self._test_id}')
         self.client = GoalManagerClient(self.node)
 
         self.server_pub = self.node.create_publisher(
@@ -139,6 +148,29 @@ class TestGoalManagerClientUnit(unittest.TestCase):
             lambda: self.client.get_state() == ClientState.NAVIGATION_FAILED, timeout=2.0)
         self.assertTrue(ok, 'Expected NAVIGATION_FAILED after FAILED')
 
+    def test_unexpected_message_while_accepted_and_navigating(self):
+        # Regression test: _on_control()'s ACCEPTED_AND_NAVIGATING branch used to build
+        # its error log with `'...%d...%s' % msg.type, msg.status_message` — a missing
+        # tuple, so the string formatting itself raised TypeError (not enough arguments
+        # for format string) inside the subscription callback the moment an
+        # unrecognized message.type arrived in this state. ERROR is not handled by the
+        # ACCEPTED_AND_NAVIGATING branch (only FEEDBACK/FINISHED/FAILED/CANCELLED are),
+        # so it exercises the previously-broken `case _:` path.
+        self.client.send_goals(self.goals)
+        self._publish_and_wait(
+            self._srv_msg(NavigationControl.ACCEPT),
+            lambda: self.client.get_state() == ClientState.ACCEPTED_AND_NAVIGATING)
+
+        try:
+            ok = self._publish_and_wait(
+                self._srv_msg(NavigationControl.ERROR, 'unexpected'),
+                lambda: self.client.get_state() == ClientState.ERROR)
+        except TypeError as e:
+            self.fail(f'_on_control() raised {e!r} handling an unexpected message type')
+
+        self.assertTrue(ok, 'Expected ERROR after an unrecognized message type')
+        self.assertEqual(self.client.get_result().status_message, 'unexpected')
+
     def test_preempt_local(self):
         self.client.send_goals(self.goals)
         self._publish_and_wait(
@@ -188,4 +220,72 @@ class TestGoalManagerClientUnit(unittest.TestCase):
         msg_other.nav_current_user_id = 'someone_else'
         self.server_pub.publish(msg_other)
         time.sleep(0.05)
+        self.assertEqual(self.client.get_state(), ClientState.IDLE)
+
+    def test_pause_resume(self):
+        self.client.send_goals(self.goals)
+        self._publish_and_wait(
+            self._srv_msg(NavigationControl.ACCEPT),
+            lambda: self.client.get_state() == ClientState.ACCEPTED_AND_NAVIGATING)
+
+        self.assertFalse(self.client.is_paused())
+
+        self.client.pause()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.PAUSED),
+            lambda: self.client.is_paused())
+        self.assertTrue(ok)
+        # Pausing must not change the navigation state itself.
+        self.assertEqual(self.client.get_state(), ClientState.ACCEPTED_AND_NAVIGATING)
+
+        self.client.resume()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.RESUMED),
+            lambda: not self.client.is_paused())
+        self.assertTrue(ok)
+        self.assertEqual(self.client.get_state(), ClientState.ACCEPTED_AND_NAVIGATING)
+
+    def test_pause_flag_resets_on_finish(self):
+        self.client.send_goals(self.goals)
+        self._publish_and_wait(
+            self._srv_msg(NavigationControl.ACCEPT),
+            lambda: self.client.get_state() == ClientState.ACCEPTED_AND_NAVIGATING)
+
+        self.client.pause()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.PAUSED),
+            lambda: self.client.is_paused())
+        self.assertTrue(ok)
+
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.FINISHED, 'done'),
+            lambda: self.client.get_state() == ClientState.NAVIGATION_FINISHED)
+        self.assertTrue(ok)
+        self.assertFalse(self.client.is_paused())
+
+    def test_pause_resume_from_idle_third_party(self):
+        # Unlike cancel(), pause()/resume() are not restricted to a goal this
+        # client itself commanded: an operator tool or a fleet-level conflict
+        # monitor may call them while this client's own state is still IDLE
+        # (it never sent a goal of its own), and still observe the PAUSED
+        # confirmation for whatever navigation is active elsewhere.
+        self.assertEqual(self.client.get_state(), ClientState.IDLE)
+
+        try:
+            self.client.pause()
+        except Exception as e:
+            self.fail(f'pause() raised while IDLE: {e}')
+
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.PAUSED),
+            lambda: self.client.is_paused())
+        self.assertTrue(ok)
+        # Client-side goal-ownership state must stay untouched.
+        self.assertEqual(self.client.get_state(), ClientState.IDLE)
+
+        self.client.resume()
+        ok = self._publish_and_wait(
+            self._srv_msg(NavigationControl.RESUMED),
+            lambda: not self.client.is_paused())
+        self.assertTrue(ok)
         self.assertEqual(self.client.get_state(), ClientState.IDLE)


### PR DESCRIPTION
Hi,

This PR allows to pause navigation, without cancelling the current navigation. The approach is adding a entry in NavState, set by GoalManager, indicating that the navigation is paused. When paused, everything is working, but the final output speed is zero.

I have added two new CLI verbs:
`ros2 easynav pause`
`ros2 easynav resume`

And `GoalManagerClient`(both C++ and Python versions) has new methods:
```
void pause();
void resume();
bool is_paused();
``` 

https://github.com/user-attachments/assets/2d0779bf-0345-4859-8543-94cded877b34

I hope you find it cool