### PR TITLE
Fix the log name depending on the namespace

### DIFF
--- a/easynav_common/include/easynav_common/YTSession.hpp
+++ b/easynav_common/include/easynav_common/YTSession.hpp
@@ -16,8 +16,7 @@
 #ifndef EASYNAV_COMMON_TYPES__YTSESSION_HPP_
 #define EASYNAV_COMMON_TYPES__YTSESSION_HPP_
 
-#include <unistd.h>
-
+#include <algorithm>
 #include <string>
 
 #include "easynav_common/Singleton.hpp"
@@ -34,8 +33,14 @@ namespace easynav
 class YTSession : public yaets::TraceSession, public Singleton<YTSession>
 {
 public:
-  explicit YTSession()
-  : yaets::TraceSession(log_path())
+  /// \param ros_namespace The owning node's ROS namespace (e.g. "/robot_1" or
+  ///   "/"), used to pick this instance's trace log path -- see log_path().
+  ///   Only the first call across getInstance()/get() overloads (from any
+  ///   translation unit) actually constructs the singleton, so this must be
+  ///   supplied before any EASYNAV_TRACE_EVENT/EASYNAV_TRACE_NAMED_EVENT
+  ///   fires; system_main.cpp does this right after creating system_node.
+  explicit YTSession(const std::string & ros_namespace = "")
+  : yaets::TraceSession(log_path(ros_namespace))
   {}
 
   ~YTSession()
@@ -46,10 +51,27 @@ public:
   SINGLETON_DEFINITIONS(YTSession)
 
 private:
-  /// \brief Per-process trace log path: /tmp/easynav_<pid>.log.
-  static std::string log_path()
+  /// \brief Trace log path, keyed by ROS namespace so that multiple EasyNav
+  /// instances (one per robot) each get their own file the TUI/CLI tools can
+  /// find without needing to know a PID: "/tmp/easynav.log" for the root
+  /// namespace ("" or "/"), "/tmp/easynav_<ns>.log" (leading/trailing
+  /// slashes stripped, inner slashes turned into "_") otherwise -- e.g.
+  /// "/robot_1" -> "/tmp/easynav_robot_1.log".
+  static std::string log_path(const std::string & ros_namespace)
   {
-    return "/tmp/easynav_" + std::to_string(::getpid()) + ".log";
+    std::string ns = ros_namespace;
+    while (!ns.empty() && ns.front() == '/') {
+      ns.erase(ns.begin());
+    }
+    while (!ns.empty() && ns.back() == '/') {
+      ns.pop_back();
+    }
+    std::replace(ns.begin(), ns.end(), '/', '_');
+
+    if (ns.empty()) {
+      return "/tmp/easynav.log";
+    }
+    return "/tmp/easynav_" + ns + ".log";
   }
 };
 

--- a/easynav_system/src/system_main.cpp
+++ b/easynav_system/src/system_main.cpp
@@ -69,6 +69,16 @@ int main(int argc, char ** argv)
 
     auto system_node = easynav::SystemNode::make_shared();
 
+#ifdef EASYNAV_DEBUG_WITH_YAETS
+    // Must run before any EASYNAV_TRACE_EVENT/EASYNAV_TRACE_NAMED_EVENT in
+    // this process (the first such call constructs the YTSession singleton
+    // and its namespace can't be changed afterwards): picks this instance's
+    // trace log ("/tmp/easynav_<ns>.log", or "/tmp/easynav.log" if
+    // unnamespaced) so multiple EasyNav instances don't collide and the
+    // TUI/CLI tools can find the right one by namespace instead of PID.
+    easynav::YTSession::getInstance(std::string(system_node->get_namespace()));
+#endif
+
     exe_nort.add_node(system_node->get_node_base_interface());
     exe_rt.add_callback_group(system_node->get_real_time_cbg(),
                               system_node->get_node_base_interface());
@@ -154,10 +164,11 @@ int main(int argc, char ** argv)
           if (system_node->get_current_state().id() ==
           lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
           {
+            EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_rt=cycle");
             system_node->system_cycle_rt();
           }
           {
-            EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_rt");
+            EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_rt=callbacks");
             exe_rt.spin_all(spin_duration_rt);
           }
           rate.sleep();
@@ -171,10 +182,11 @@ int main(int argc, char ** argv)
       if (system_node->get_current_state().id() ==
         lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
       {
+        EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_nort=cycle");
         system_node->system_cycle();
       }
       {
-        EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_nort");
+        EASYNAV_TRACE_NAMED_EVENT("easynav_system::spin_nort=callbacks");
         exe_nort.spin_all(spin_duration_nort);
       }
       rate.sleep();

--- a/easynav_tools/easynav_tools/cli/timetats.py
+++ b/easynav_tools/easynav_tools/cli/timetats.py
@@ -30,14 +30,15 @@ class TimeStatsVerb(VerbExtension):
         add_arguments(parser)
         parser.add_argument('--duration', type=float, default=5000.0, help='Seconds to run')
         parser.add_argument(
-            '--pid', type=int, default=None,
-            help='PID of the EasyNav process to read stats from. Defaults to '
-                 'auto-discovering the most recently modified /tmp/easynav_<pid>.log; '
-                 'only needed when more than one EasyNav process is running on this host.')
+            '--namespace', type=str, default=None,
+            help='ROS namespace of the EasyNav instance to read stats from (e.g. '
+                 '"robot_1"). Defaults to auto-discovering the most recently modified '
+                 '/tmp/easynav*.log; only needed when more than one EasyNav instance '
+                 'is running on this host.')
 
     def main(self, *, args):
         try:
-            log_reader = LogReader(pid=args.pid)
+            log_reader = LogReader(namespace=args.namespace)
 
             t_end = time.time() + args.duration
             while time.time() < t_end:

--- a/easynav_tools/easynav_tools/controller/ros_controllers.py
+++ b/easynav_tools/easynav_tools/controller/ros_controllers.py
@@ -239,22 +239,33 @@ class NavStateProcessor():
 
 
 # ---------- Time stats config ----------
-# Each EasyNav process writes its own /tmp/easynav_<pid>.log (a single shared
-# /tmp/easynav.log broke with multiple concurrent instances on the same host).
-_LOG_GLOB = '/tmp/easynav_*.log'
+# Each EasyNav process writes its own /tmp/easynav_<ns>.log, keyed by ROS
+# namespace rather than PID (a single shared /tmp/easynav.log broke with
+# multiple concurrent instances on the same host; a PID-keyed name made the
+# file unfindable without knowing the PID -- see easynav::YTSession).
+_LOG_GLOB = '/tmp/easynav*.log'
 _LOG_RE = re.compile(r'^(?P<name>\S+)\s+(?P<start>\d+)\s+(?P<end>\d+)\s*$')
 
 
-def _discover_log_path(pid: int | None = None) -> str | None:
+def _namespace_to_log_path(namespace: str) -> str:
+    """Mirror easynav::YTSession::log_path()'s namespace -> filename mapping."""
+    ns = namespace.strip('/')
+    if not ns:
+        return '/tmp/easynav.log'
+    return f'/tmp/easynav_{ns.replace("/", "_")}.log'
+
+
+def _discover_log_path(namespace: str | None = None) -> str | None:
     """Resolve the trace-log path for a running EasyNav instance.
 
-    With an explicit pid, targets that instance directly. Otherwise, auto-discovers
-    among currently-present /tmp/easynav_<pid>.log files, picking the most recently
-    modified one if more than one EasyNav instance is running. Returns None if no
-    pid was given and no log file exists yet (e.g. EasyNav hasn't started).
+    With an explicit namespace, targets that instance directly. Otherwise,
+    auto-discovers among currently-present /tmp/easynav*.log files, picking
+    the most recently modified one if more than one EasyNav instance is
+    running. Returns None if no namespace was given and no log file exists
+    yet (e.g. EasyNav hasn't started).
     """
-    if pid is not None:
-        return f'/tmp/easynav_{pid}.log'
+    if namespace is not None:
+        return _namespace_to_log_path(namespace)
 
     dated_candidates = []
     for path in glob.glob(_LOG_GLOB):
@@ -306,9 +317,9 @@ def _sort_key_suffix(full: str) -> tuple[str, str]:
 
 class LogReader:
 
-    def __init__(self, pid: int | None = None):
+    def __init__(self, namespace: str | None = None):
         # ---- Time stats state (tailing the log) ----
-        self._log_path = _discover_log_path(pid)
+        self._log_path = _discover_log_path(namespace)
         self._log_fh = None
         self._log_inode = None
         self._log_pos = 0

--- a/easynav_tools/easynav_tools/tui/app.py
+++ b/easynav_tools/easynav_tools/tui/app.py
@@ -179,7 +179,10 @@ class EasyNavTabbedApp(App):
         self._last_twist_text = '—'
         self._last_twiststamped_text = '—'
 
-        self.log_reader = LogReader()
+        # self.node's namespace already reflects any "-r __ns:=..." remap the
+        # TUI was launched with, so the trace log for that same EasyNav
+        # instance is found without a separate --namespace flag.
+        self.log_reader = LogReader(namespace=self.node.get_namespace())
 
     def compose(self) -> ComposeResult:
         yield Tabs(


### PR DESCRIPTION
Hi,

A recent change made the yaets logs to include the PID in the name, in order to prevent any conflict when multiple instances of EasyNav are running. This is a problem for the TUI to localize the file. This PR changes this, and the log filename depends on the namespace, so a namespaced TUI can find it correctly.

I hope it helps