### PR TITLE
Add discovered check method for Goal Manager Client

### DIFF
--- a/easynav_system/include/easynav_system/GoalManagerClient.hpp
+++ b/easynav_system/include/easynav_system/GoalManagerClient.hpp
@@ -112,6 +112,15 @@ public:
   [[nodiscard]] State get_state() const {return state_;}
 
   /**
+  * @brief Check whether another subscriber besides the client is present on the control topic.
+  * @return True if at least one additional control-topic subscriber is detected.
+  */
+  [[nodiscard]] bool is_connected() const
+  {
+    return control_pub_->get_subscription_count() > 1;
+  }
+
+  /**
    * @brief Get the last control message sent or received.
    * @return Reference to the last control message.
    */


### PR DESCRIPTION
Hi,

As discussed in #117, here is the method to help check whether the Goal Manager has been discovered.

The client already subscribes to the shared control topic, so a subscription count greater than one indicates that another subscriber, normally the GoalManager, has been discovered. This provides a simple discovery check before sending requests. This can help avoid connection-related issues.

Best,
Esther